### PR TITLE
editorconfig設定とvscodeの推奨extensions追加

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+root = true
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,3 @@
 {
-  "recommendations": ["bradlc.vscode-tailwindcss"]
+  "recommendations": ["bradlc.vscode-tailwindcss", "graphql.vscode-graphql", "prisma.prisma", "EditorConfig.EditorConfig"]
 }


### PR DESCRIPTION
もし必要そうならで、

editorconfigを導入してインデント幅などエディタの設定を明示・統一すると良いかなと思いました。
※ 設定がこれでよいか細かくは未確認

.graphqlと.prismaのファイル用のvscodeの推奨extensionsを追加してみました。